### PR TITLE
Reorganize Ochami services and hurl tests

### DIFF
--- a/lanl/docker-compose/README.md
+++ b/lanl/docker-compose/README.md
@@ -4,9 +4,11 @@
 
 - `ochami-services.yml`: The main deployment file. Runs SMD and BSS with JWT
   authentication enabled, plus postgres for SMD/BSS data storage and dnsmasq for
-  handling DHCP requests from nodes.
-- `ochami-services-noauth.yml`: Runs SMD and BSS with JWT authentication
-  disabled. Depends on the postgres container in `ochami-services.yml`.
+  handling DHCP requests from nodes. Depends on `hydra.yml`. This file can be
+  run independently of or alongside `ochami-services-noauth.yml`.
+- `ochami-services-noauth.yml`: Like `ochami-services.yml`, but runs SMD and BSS
+  with JWT authentication disabled. This file can be run independently of or
+  alongside `ochami-services.yml`.
 - `ochami-hurl-tests.yaml`: Runs integration tests using Hurl against the
   authentication-enabled BSS and SMD in `ochami-services.yml`.
 - `ochami-hurl-tests-noauth.yml`: Runs integration tests using Hurl against the
@@ -22,36 +24,35 @@
    read by Docker Compose.
 1. SMD and BSS support optional JWT authentication. `ochami-services.yml` runs
    SMD and BSS with it enabled while `ochami-services-noauth.yaml` runs SMD and
-   BSS without it (although it depends on `ochami-services.yml` still).
+   BSS without it.
 
    To run the services with JWT authentication enabled:
 
    ```
-   docker compose -f ochami-services.yml -f ochami-krakend-ce.yml up
+   docker compose -f ochami-services.yml -f hydra.yml -f ochami-krakend-ce.yml up
    ```
 
-   **NOTE:** Authenticated BSS and SMD run on ports 27778 and 27779,
+   **NOTE:** Authenticated BSS and SMD run on host ports 27778 and 27779,
+   respectively.
+
+   To run the services without JWT authentication enabled:
+
+   ```
+   docker compose -f ochami-services-noauth.yml -f ochami-krakend-ce.yml
+   ```
+
+   **NOTE:** Non-authenticated BSS and SMD run on host ports 37778 and 37779,
    respectively.
 
    To run both authenticated and non-authenticated services simultaneously:
 
    ```
-   docker compose -f ochami-services.yml -f ochami-krakend-ce.yml -f ochami-services-noauth.yml -f hydra.yml up
-   ```
-
-   **NOTE:** Non-authenticated BSS and SMD run on ports 37778 and 37779,
-   respectively.
-
-   Alternatively, to run *just* the unauthenticated services with the API
-   gateway, specify the containers:
-
-   ```
    docker compose \
      -f ochami-services.yml \
-     -f ochami-krakend-ce.yml \
      -f ochami-services-noauth.yml \
-     up \
-     postgres bss-noauth smd-noauth krakend-ce
+     -f hydra.yml \
+     -f ochami-krakend-ce.yml \
+     up
    ```
 1. After a minute or so you can check the health of SMD:
 
@@ -84,7 +85,7 @@ docker compose -f ochami-services.yml -f ochami-hurl-tests.yml -f hydra.yml up
 To run the unauthenticated integration tests:
 
 ```
-docker compose -f ochami-services.yml -f ochami-services-noauth.yml -f ochami-hurl-tests-noauth.yml up
+docker compose -f ochami-services-noauth.yml -f ochami-hurl-tests-noauth.yml up
 ```
 
 To run both the authenticated and unauthenticated integration tests:

--- a/lanl/docker-compose/ochami-hurl-tests-noauth.yml
+++ b/lanl/docker-compose/ochami-hurl-tests-noauth.yml
@@ -8,7 +8,7 @@ services:
     volumes:
       - ./tests/noauth:/tests:ro
     networks:
-      - internal
+      - internal-noauth
     depends_on:
         smd-noauth:
           condition: service_healthy

--- a/lanl/docker-compose/ochami-services-noauth.yml
+++ b/lanl/docker-compose/ochami-services-noauth.yml
@@ -9,33 +9,77 @@ version: '3.7'
 # echo "BSS_POSTGRES_PASSWORD=$(openssl rand -base64 32 | openssl dgst | cut -d' ' -f2)" >> .env
 # echo "HYDRA_POSTGRES_PASSWORD=$(openssl rand -base64 32 | openssl dgst | cut -d' ' -f2)" >> .env
 
-
 networks:
-  internal:
-  external:
+  internal-noauth:
+  external-noauth:
     external: true
 
 volumes:
-  postgres-data:
+  postgres-data-noauth:
 
 services:
-  # SMD with auth requirement disabled
-  smd-noauth:
-    hostname: smd-noauth
-    container_name: smd-noauth
-    image: ghcr.io/openchami/smd:v2.14.2
+  postgres-noauth: # Postgres
+    image: postgres:11.5-alpine
+    container_name: postgres-noauth
+    hostname: postgres-noauth
+    restart: always
     environment:
-      - SMD_DBHOST=postgres
+      POSTGRES_USER: ochami
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD} # Set in .env file for now.
+      POSTGRES_MULTIPLE_DATABASES: hmsds:smd-user:${SMD_POSTGRES_PASSWORD},bssdb:bss-user:${BSS_POSTGRES_PASSWORD}
+    volumes:
+      - postgres-data-noauth:/var/lib/postgresql/data
+      - ./pg-init:/docker-entrypoint-initdb.d
+    networks:
+      - internal-noauth
+    ports:
+      - 5433:5432
+    healthcheck:
+      test: ["CMD", "pg_isready", "--dbname", "ochami", "--username", "ochami"]
+      interval: 10s
+      timeout: 10s
+      retries: 5
+###
+# SMD Init and Server Containers (auth disabled)
+###
+  # sets up postgres for SMD data
+  smd-init-noauth:
+    image: ghcr.io/openchami/smd:v2.14.2
+    container_name: smd-init-noauth
+    hostname: smd-init-noauth
+    environment:
+      - SMD_DBHOST=postgres-noauth
       - SMD_DBPORT=5432
       - SMD_DBUSER=smd-user
       - SMD_DBPASS=${SMD_POSTGRES_PASSWORD} # Set in .env file
       - SMD_DBNAME=hmsds
       - SMD_DBOPTS=sslmode=disable
     depends_on:
-      - postgres
-      - smd-init
+      postgres-noauth:
+        condition: service_healthy
+    networks:
+      - internal-noauth
+    entrypoint:
+      - /smd-init
+  # SMD with auth requirement disabled
+  smd-noauth:
+    image: ghcr.io/openchami/smd:v2.14.2
+    container_name: smd-noauth
+    hostname: smd-noauth
+    environment:
+      - SMD_DBHOST=postgres-noauth
+      - SMD_DBPORT=5432
+      - SMD_DBNAME=hmsds
+      - SMD_DBUSER=smd-user
+      - SMD_DBPASS=${SMD_POSTGRES_PASSWORD} # Set in .env file
+      - SMD_DBOPTS=sslmode=disable
+    depends_on:
+      postgres-noauth:
+        condition: service_healthy
+      smd-init-noauth:
+        condition: service_completed_successfully
     ports:
-      - "37779:27779"
+      - "27799:27779"
     healthcheck:
       test: ["CMD", "curl", "--fail", "--silent", "http://localhost:27779/hsm/v2/service/ready"]
       interval: 5s
@@ -43,7 +87,30 @@ services:
       start_period: 20s
       timeout: 10s
     networks:
-      - internal
+      - internal-noauth
+###
+# BSS Init and Server Containers (auth disabled)
+###
+# sets up postgres for BSS data
+  bss-init-noauth:
+    hostname: bss-init-noauth
+    container_name: bss-init-noauth
+    image: ghcr.io/openchami/bss:v1.29.0
+    environment:
+      - BSS_USESQL=true
+      - BSS_INSECURE=true
+      - BSS_DBHOST=postgres-noauth
+      - BSS_DBPORT=5432
+      - BSS_DBNAME=bssdb
+      - BSS_DBUSER=bss-user
+      - BSS_DBPASS=${BSS_POSTGRES_PASSWORD} # Set in .env file
+    depends_on:
+      postgres-noauth:
+        condition: service_healthy
+    networks:
+      - internal-noauth
+    entrypoint:
+      - /usr/local/bin/bss-init
   # boot-script-service
   bss-noauth:
     hostname: bss-noauth
@@ -52,22 +119,45 @@ services:
     environment:
       - BSS_USESQL=true
       - BSS_INSECURE=true
-      - BSS_DBHOST=postgres
-      - BSS_DBNAME=bssdb
+      - BSS_DBHOST=postgres-noauth
       - BSS_DBPORT=5432
+      - BSS_DBNAME=bssdb
       - BSS_DBUSER=bss-user
       - BSS_DBPASS=${BSS_POSTGRES_PASSWORD} # Set in .env file
       - HSM_URL=http://smd-noauth:27779
     ports:
-      - '37778:27778'
+      - '27788:27778'
     depends_on:
-      - postgres
-      - bss-init
-      - smd
+      postgres-noauth:
+        condition: service_healthy
+      smd-noauth:
+        condition: service_healthy
+      bss-init-noauth:
+        condition: service_completed_successfully
     networks:
-      - internal
+      - internal-noauth
     healthcheck:
       test: ["CMD", "curl", "--fail", "--silent", "http://localhost:27778/boot/v1/service/status"]
+      interval: 5s
+      timeout: 10s
+      retries: 60
+  dnsmasq-noauth:
+    image: ghcr.io/openchami/dnsmasq:dynamic
+    container_name: dnsmasq-dhcp-noauth
+    hostname: dnsmasq-dhcp-noauth
+    environment:
+      - smd_endpoint=172.16.0.253
+      - bss_endpoint=172.16.0.253
+    depends_on:
+      bss-noauth:
+        condition: service_healthy
+      smd-noauth:
+        condition: service_healthy
+    network_mode: "host"
+    cap_add:
+      - NET_ADMIN
+    healthcheck:
+      test: pgrep dnsmasq
       interval: 5s
       timeout: 10s
       retries: 60

--- a/lanl/docker-compose/ochami-services.yml
+++ b/lanl/docker-compose/ochami-services.yml
@@ -44,39 +44,41 @@ services:
 ###
   # sets up postgres for SMD data
   smd-init:
-    container_name: smd-init
     image: ghcr.io/openchami/smd:v2.14.2
+    container_name: smd-init
+    hostname: smd-init
     environment:
       - SMD_DBHOST=postgres
       - SMD_DBPORT=5432
+      - SMD_DBNAME=hmsds
       - SMD_DBUSER=smd-user
       - SMD_DBPASS=${SMD_POSTGRES_PASSWORD} # Set in .env file
-      - SMD_DBNAME=hmsds
       - SMD_DBOPTS=sslmode=disable
-    hostname: smd-init
     depends_on:
       postgres:
         condition: service_healthy
     networks:
       - internal
     entrypoint:
-      - /smd-init 
-  # SMD 
+      - /smd-init
+  # SMD
   smd:
-    container_name: smd
     image: ghcr.io/openchami/smd:v2.14.2
+    container_name: smd
+    hostname: smd
     environment:
       - SMD_DBHOST=postgres
       - SMD_DBPORT=5432
+      - SMD_DBNAME=hmsds
       - SMD_DBUSER=smd-user
       - SMD_DBPASS=${SMD_POSTGRES_PASSWORD} # Set in .env file
-      - SMD_DBNAME=hmsds
       - SMD_DBOPTS=sslmode=disable
       - SMD_JWKS_URL=http://hydra:4444/.well-known/jwks.json
-    hostname: smd
     depends_on:
-      - postgres
-      - smd-init
+      postgres:
+        condition: service_healthy
+      smd-init:
+        condition: service_completed_successfully
     ports:
       - "27779:27779"
     healthcheck:
@@ -92,15 +94,15 @@ services:
 ###
 # sets up postgres for BSS data
   bss-init:
-    hostname: bss-init
-    container_name: bss-init
     image: ghcr.io/openchami/bss:v1.29.0
+    container_name: bss-init
+    hostname: bss-init
     environment:
       - BSS_USESQL=true
       - BSS_INSECURE=true
       - BSS_DBHOST=postgres
-      - BSS_DBNAME=bssdb
       - BSS_DBPORT=5432
+      - BSS_DBNAME=bssdb
       - BSS_DBUSER=bss-user
       - BSS_DBPASS=${BSS_POSTGRES_PASSWORD} # Set in .env file
     depends_on:
@@ -112,15 +114,16 @@ services:
       - /usr/local/bin/bss-init
   # boot-script-service
   bss:
-    hostname: bss
-    container_name: bss
     image: ghcr.io/openchami/bss:v1.29.0
+    container_name: bss
+    hostname: bss
     environment:
       - BSS_USESQL=true
       - BSS_INSECURE=true
+      - BSS_DEBUG=true
       - BSS_DBHOST=postgres
-      - BSS_DBNAME=bssdb
       - BSS_DBPORT=5432
+      - BSS_DBNAME=bssdb
       - BSS_DBUSER=bss-user
       - BSS_DBPASS=${BSS_POSTGRES_PASSWORD} # Set in .env file
       - BSS_AUTH_REQUIRED=true
@@ -130,10 +133,14 @@ services:
     ports:
       - '27778:27778'
     depends_on:
-      - postgres
-      - bss-init
-      - smd
-      - hydra
+      postgres:
+        condition: service_healthy
+      smd:
+        condition: service_healthy
+      bss-init:
+        condition: service_completed_successfully
+      hydra:
+        condition: service_healthy
     networks:
       - internal
     healthcheck:
@@ -142,19 +149,21 @@ services:
       timeout: 10s
       retries: 60
   dnsmasq:
-    hostname: dnsmasq-dhcp
-    container_name: dnsmasq-dhcp
     image: ghcr.io/openchami/dnsmasq:dynamic
+    container_name: dnsmasq-dhcp
+    hostname: dnsmasq-dhcp
     environment:
       - smd_endpoint=172.16.0.253
       - bss_endpoint=172.16.0.253
     depends_on:
-      - bss
-      - smd
+      bss:
+        condition: service_healthy
+      smd:
+        condition: service_healthy
     network_mode: "host"
     cap_add:
       - NET_ADMIN
-    healthcheck: 
+    healthcheck:
       test: pgrep dnsmasq
       interval: 5s
       timeout: 10s


### PR DESCRIPTION
Currently, `ochami-services-noauth.yml` depends on `ochami-services.yml` to run  because of the shared Postgres database. If one only wants to run the unauthenticated tests, running the authenticated services also is unnecessary. This PR makes `ochami-services-noauth.yml` independent from `ochami-services.yml` so that the unauthenticated and authenticated services can be run separately, each on its own, or even together.

This PR also makes the container dependencies explicit (i.e. whether each dependency is `service_healthy` or `service_completed_successfully`).